### PR TITLE
V8 build fix. Add Aspire to build flow

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,10 @@ parameters:
   displayName: Tag for sdk repository
   type: string
   default: v8.0.100
+- name: aspireBranch
+  displayName: Tag for aspire repository
+  type: string
+  default: v8.0.0-preview.1.23557.2
 - name: installerBranch
   displayName: Tag for installer repository
   type: string
@@ -36,6 +40,11 @@ resources:
     endpoint: Servarr
     name: dotnet/sdk
     ref: release/8.0.1xx
+  - repository: aspire
+    type: github
+    endpoint: Servarr
+    name: dotnet/aspire
+    ref: release/8.0-preview1
   - repository: installer
     type: github
     endpoint: Servarr
@@ -99,6 +108,27 @@ stages:
       vmImage: 'ubuntu-22.04'
 
     jobs:
+      - job: Aspire
+        timeoutInMinutes: 0
+        steps:
+          - checkout: self
+          - checkout: aspire
+          - bash: |
+              set -e
+              git -C aspire checkout ${{ parameters.aspireBranch }}
+            displayName: Checkout and patch
+          - bash: |
+              aspire/build.sh --restore --build --pack --ci /p:OfficialBuildId=20231101.7
+            displayName: Build SDK
+          - publish: '$(Build.SourcesDirectory)/aspire/artifacts/packages/Release/Shipping/'
+            artifact: AspirePackages
+            displayName: Publish Aspire
+          - publish: '$(Build.SourcesDirectory)/sdk/artifacts/log'
+            condition: succeededOrFailed()
+            artifact: AspireLogs
+            displayName: Publish Build Logs
+
+    jobs:
       - job: Sdk
         timeoutInMinutes: 0
         steps:
@@ -121,7 +151,6 @@ stages:
             condition: succeededOrFailed()
             artifact: SdkLogs
             displayName: Publish Build Logs
-
 
   - stage: AspNetCore
     dependsOn: Runtime
@@ -195,6 +224,7 @@ stages:
               dotnet nuget remove source nuget-build --configfile installer/NuGet.config || true
               dotnet nuget add source ../runtime/artifacts/packages/Release/Shipping --name runtime --configfile installer/NuGet.config
               dotnet nuget add source ../aspnetcore/artifacts/packages/Release/Shipping --name aspnetcore --configfile installer/NuGet.config
+              dotnet nuget add source ../aspire/artifacts/packages/Release/Shipping --name aspire --configfile installer/NuGet.config
               sed -i '/\/dnceng\/internal\//d' installer/NuGet.config
             displayName: Checkout and patch
           - task: DownloadPipelineArtifact@2
@@ -212,6 +242,13 @@ stages:
               targetPath: '$(Build.SourcesDirectory)/aspnetcore/artifacts/packages/Release/Shipping'
               patterns: |
                 Microsoft.*.freebsd-x64.*.nupkg
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              buildType: 'current'
+              artifactName: AspirePackages
+              targetPath: '$(Build.SourcesDirectory)/aspire/artifacts/packages/Release/Shipping'
+              patterns: |
+                Microsoft.*.nupkg
           - task: DownloadPipelineArtifact@2
             inputs:
               buildType: 'current'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -201,11 +201,11 @@ stages:
             artifact: AspNetCoreLogs
             displayName: Publish Build Logs
 
-
   - stage: Installer
     dependsOn:
       - AspNetCore
       - Sdk
+      - Aspire
     pool:
       vmImage: 'ubuntu-22.04'
     jobs:


### PR DESCRIPTION
net8 post-RC2 requires manual building of Aspire as the version number is only available in internal NuGet feeds

`OfficialBuildId` is manually set Aspire contains neither the required branch nor tag to back engineering via existing script. This will hopefully change in the future

Commits authored with GH's terribad text editor with no ability to check for linting or even validity. Fun!

Suggestions, but not in commit: 

Code cleanup: ASPNETCore has explicit support for FreeBSD since dotNET7 and requires no patching. Sourcebuilds/nonportable-builds inject support automagically (e.g., VMR)

Upcoming Issues: FreeBSD 11 and 12 are EOL. Please do not build against these. 13.2 and 14.0 are not ABI compatible when it comes to OpenSSL and starting next quarter 14.0 will not even contain OpenSSL 1.1 in ports as the default meta package. These are problems for future-me